### PR TITLE
Fix overlap return

### DIFF
--- a/R/overlap.R
+++ b/R/overlap.R
@@ -44,4 +44,5 @@ fixation_overlap <- function(x, y, dthresh=60, time_samples=seq(0,max(x$onset), 
   d <- proxy::dist(fx1[,1:2], fx2[,1:2], pairwise=TRUE, method=method)
   overlap <- sum(d[!is.na(d)] < dthresh)
   perc <- overlap/length(d)
+  list(overlap = overlap, perc = perc)
 }

--- a/tests/testthat/test_fixation_overlap.R
+++ b/tests/testthat/test_fixation_overlap.R
@@ -1,0 +1,22 @@
+library(testthat)
+
+context("fixation_overlap")
+
+test_that("fixation_overlap returns structure and valid ranges", {
+  x <- seq(0, 90, by = 10)
+  y <- x
+  fg1 <- fixation_group(x = x, y = y, duration = rep(1, length(x)), onset = x)
+  fg2 <- fixation_group(x = x, y = y, duration = rep(1, length(x)), onset = x)
+
+  res <- fixation_overlap(fg1, fg2, time_samples = x, dthresh = 1e-6)
+
+  expect_true(is.list(res))
+  expect_equal(names(res), c("overlap", "perc"))
+  expect_true(is.numeric(res$overlap))
+  expect_equal(length(res$overlap), 1)
+  expect_true(res$overlap >= 0 && res$overlap <= length(x))
+  expect_true(is.numeric(res$perc))
+  expect_equal(length(res$perc), 1)
+  expect_equal(res$perc, res$overlap/length(x))
+  expect_true(res$perc >= 0 && res$perc <= 1)
+})


### PR DESCRIPTION
## Summary
- ensure `fixation_overlap` returns a list
- add regression test for `fixation_overlap`

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(fails: command not found)*