### PR TITLE
Add EMD similarity option

### DIFF
--- a/R/repetitive_similarity.R
+++ b/R/repetitive_similarity.R
@@ -67,7 +67,7 @@
 repetitive_similarity <- function(tab,
                                   density_var = "density",
                                   condition_var,
-                                  method = c("spearman", "pearson", "fisherz", "cosine", "l1", "jaccard", "dcov"),
+                                  method = c("spearman", "pearson", "fisherz", "cosine", "l1", "jaccard", "dcov", "emd"),
                                   pairwise = FALSE,
                                   multiscale_aggregation = "mean",
                                   ...) {

--- a/man/template_similarity.Rd
+++ b/man/template_similarity.Rd
@@ -11,7 +11,7 @@ template_similarity(
   permute_on = NULL,
   refvar = "density",
   sourcevar = "density",
-  method = c("spearman", "pearson", "fisherz", "cosine", "l1", "jaccard", "dcov"),
+  method = c("spearman", "pearson", "fisherz", "cosine", "l1", "jaccard", "dcov", "emd"),
   permutations = 10,
   ...
 )
@@ -29,7 +29,7 @@ template_similarity(
 
 \item{sourcevar}{A character string representing the name of the variable containing density maps in the source table (default is "density").}
 
-\item{method}{A character string specifying the similarity method to use. Possible values are "spearman", "pearson", "fisherz", "cosine", "l1", "jaccard", and "dcov" (default is "spearman").}
+\item{method}{A character string specifying the similarity method to use. Possible values are "spearman", "pearson", "fisherz", "cosine", "l1", "jaccard", and "dcov", "emd" (default is "spearman").}
 
 \item{permutations}{A numeric value specifying the number of permutations for the baseline map (default is 10).}
 

--- a/tests/testthat/test_similarity_emd.R
+++ b/tests/testthat/test_similarity_emd.R
@@ -1,0 +1,15 @@
+library(testthat)
+
+test_that("EMD similarity equals 1 for identical maps", {
+  d <- list(x = 1:2, y = 1:2, z = matrix(c(0.25,0.25,0.25,0.25), nrow=2))
+  class(d) <- c("eye_density", "density", "list")
+  expect_equal(similarity(d, d, method="emd"), 1)
+})
+
+test_that("signed EMD returns 0 for identical residuals", {
+  d <- list(x = 1:2, y = 1:2, z = matrix(c(0.3,0.2,0.2,0.3), nrow=2))
+  class(d) <- c("eye_density", "density", "list")
+  sal <- list(x = 1:2, y = 1:2, z = matrix(0.25, nrow=2, ncol=2))
+  class(sal) <- c("eye_density", "density", "list")
+  expect_equal(similarity(d, d, method="emd", saliency_map=sal), 0)
+})


### PR DESCRIPTION
## Summary
- add `emd` method to `similarity.density`
- allow optional saliency map to compute signed EMD
- document new method in `template_similarity` docs
- support `emd` in `repetitive_similarity`
- test new functionality

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: `bash: R: command not found`)*