### PR TITLE
Fix future.rng option typo

### DIFF
--- a/tests/testthat/test_center_fixations.R
+++ b/tests/testthat/test_center_fixations.R
@@ -1,6 +1,6 @@
 
 context("centering")
-options(future.rng.onMisue = "ignore")
+options(future.rng.onMisuse = "ignore")
 
 test_that("can center a fixation_group", {
   x <- runif(10)

--- a/tests/testthat/test_template_similarity.R
+++ b/tests/testthat/test_template_similarity.R
@@ -4,7 +4,7 @@ library(dplyr)
 context("density_by")
 
 test_that("template_similarity produces perfect similarity for identical patterns", {
-  options(future.rng.onMisue = "ignore")
+  options(future.rng.onMisuse = "ignore")
   g1 <- tibble(fixgroup=lapply(1:10, function(i) {
     x <- runif(10)
     y <- runif(10)


### PR DESCRIPTION
## Summary
- correct the misspelling of `future.rng.onMisuse` in two test files

## Testing
- `R -q -e 'devtools::test()'` *(fails: `R` command not found)*