### PR TITLE
Fix crqa wrapper function

### DIFF
--- a/R/crqa.R
+++ b/R/crqa.R
@@ -8,7 +8,7 @@ crqa <- function(fg1, fg2, radius=60, delay=1, embed=1, rescale=0, metric=c("euc
   nr <- min(nr1,nr2)
 
   ts1 <- as.matrix(fg1[1:nr, 1:2])
-  ts2 <- as.matrix(fg1[1:nr, 1:2])
-  ret <- crqa(ts1,ts2, method="mdcrqa", radius=radius)
+  ts2 <- as.matrix(fg2[1:nr, 1:2])
+  ret <- crqa::crqa(ts1, ts2, method="mdcrqa", radius=radius)
   ret
 }

--- a/tests/testthat/test_crqa.R
+++ b/tests/testthat/test_crqa.R
@@ -1,0 +1,21 @@
+context("crqa wrapper")
+
+skip_if_not_installed("crqa")
+
+library(testthat)
+
+# Create simple fixation groups
+fg1 <- data.frame(x = 1:5, y = 1:5)
+fg2 <- data.frame(x = 2:6, y = 3:7)
+
+# Use package function directly for reference
+nr <- min(nrow(fg1), nrow(fg2))
+ref <- crqa::crqa(as.matrix(fg1[1:nr, 1:2]),
+                  as.matrix(fg2[1:nr, 1:2]),
+                  method = "mdcrqa", radius = 60)
+
+# Call wrapper
+res <- crqa(fg1, fg2, radius = 60)
+
+expect_equal(res, ref)
+


### PR DESCRIPTION
## Summary
- ensure crqa wrapper uses the second fixation group
- call the crqa function from the crqa package
- add regression test for the crqa wrapper

## Testing
- `R -q -e "devtools::test()"` *(fails: `R: command not found`)*