### PR TITLE
Fix typo in template_sample docs

### DIFF
--- a/R/regression.R
+++ b/R/regression.R
@@ -152,7 +152,7 @@ template_regression <- function(ref_tab, source_tab, match_on,
 #' @param source_tab the name of the table containing the density map and fixations
 #' @param template the name of the template density variable
 #' @param fixgroup the name of the fixation group supplying the spatiotemporal coordinates used to sample the template
-#' @param time the time points used to extract coordinates from the the `fixation_group`
+#' @param time the time points used to extract coordinates from the `fixation_group`
 #' @param outcol the name of the output variable
 #' @export
 #' @importFrom purrr pmap

--- a/man/template_sample.Rd
+++ b/man/template_sample.Rd
@@ -19,7 +19,7 @@ template_sample(
 
 \item{fixgroup}{the name of the fixation group supplying the spatiotemporal coordinates used to sample the template}
 
-\item{time}{the time points used to extract coordinates from the the `fixation_group`}
+\item{time}{the time points used to extract coordinates from the `fixation_group`}
 
 \item{outcol}{the name of the output variable}
 }


### PR DESCRIPTION
## Summary
- fix duplicated word in `template_sample` parameters
- update generated Rd file

## Testing
- `R -q -e "devtools::document()"` *(fails: command not found)*