### PR TITLE
Fix early exit in multi_match

### DIFF
--- a/R/multimatch.R
+++ b/R/multimatch.R
@@ -216,9 +216,9 @@ multi_match <- function(x,y, screensize) {
 
   if (nrow(x) < 3 || nrow(y) < 3) {
     warning("multi_match requires 3 or more coordinates in each scanpath, returning NAs")
-    c(mm_vector=NA, mm_direction=NA,
-      mm_length=NA, mm_position=NA,
-      mm_duration=NA)
+    return(c(mm_vector=NA, mm_direction=NA,
+             mm_length=NA, mm_position=NA,
+             mm_duration=NA))
 
   }
 


### PR DESCRIPTION
## Summary
- ensure `multi_match()` exits immediately when fewer than three fixations are supplied

## Testing
- `R` was not available, so package checks could not be run