### PR TITLE
Add transform utilities and deduplicate

### DIFF
--- a/R/density.R
+++ b/R/density.R
@@ -65,14 +65,3 @@ density_by <- function(x, groups, sigma=50, xbounds=c(0, 1000), ybounds=c(0, 100
 }
 
 
-#' @keywords internal
-#' @noRd
-rank_trans <- scales::trans_new(name="rank",
-                                transform=function(x) { rank(x) },
-                                inverse=function(x) (length(x)+1) - rank(x))
-
-#' @keywords internal
-#' @noRd
-cuberoot_trans <- scales::trans_new(name="rank",
-                                    transform=function(x) { x^(1/3) },
-                                    inverse=function(x) x^3)

--- a/R/transform_utils.R
+++ b/R/transform_utils.R
@@ -1,0 +1,29 @@
+#' Internal transformation utilities for visualization
+#'
+#' These scales transformations are used throughout the package when
+#' plotting eye density data. They are not exported.
+#'
+#' @keywords internal
+#' @noRd
+rank_trans <- scales::trans_new(
+  name = "rank",
+  transform = function(x) rank(x),
+  inverse = function(x) (length(x) + 1) - rank(x)
+)
+
+#' @keywords internal
+#' @noRd
+cuberoot_trans <- scales::trans_new(
+  name = "curoot",
+  transform = function(x) x^(1/3),
+  inverse = function(x) x^3
+)
+
+#' @keywords internal
+#' @noRd
+squareroot_trans <- scales::trans_new(
+  name = "sqroot",
+  transform = function(x) x^(1/2),
+  inverse = function(x) x^2
+)
+

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -304,19 +304,5 @@ plot.fixation_group <- function(x, type=c("points", "contour", "filled_contour",
   p
 }
 
-#' @noRd
-rank_trans <- scales::trans_new(name="rank",
-                                transform=function(x) { rank(x) },
-                                inverse=function(x) (length(x)+1) - rank(x))
-
-#' @noRd
-cuberoot_trans <- scales::trans_new(name="curoot",
-                                    transform=function(x) { x^(1/3) },
-                                    inverse=function(x) x^3)
-
-#' @noRd
-squareroot_trans <- scales::trans_new(name="sqroot",
-                                    transform=function(x) { x^(1/2) },
-                                    inverse=function(x) x^2)
 
 


### PR DESCRIPTION
## Summary
- add `R/transform_utils.R` with scale transformation helpers
- remove duplicate definitions from `R/density.R` and `R/visualization.R`
- use helpers for density and visualization transforms

## Testing
- `R` was not installed so `devtools::test()` could not be run