### PR TITLE
Fix point sizing in anim_scanpath

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -53,7 +53,7 @@ anim_scanpath <- function(x, bg_image=NULL, xlim=range(x$x),
 
 
   p <- if (type == "points") {
-    p + geom_point(aes(colour=onset, size=15), alpha=alpha, show.legend=FALSE) +
+    p + geom_point(aes(colour=onset), size=15, alpha=alpha, show.legend=FALSE) +
       scale_colour_gradientn(colours=rev(brewer.pal(n=10, "Spectral"))) +
       theme_void() + theme(panel.grid = element_blank(), panel.border = element_blank()) +
       labs(title = 'Onset: {frame_time}') +


### PR DESCRIPTION
## Summary
- ensure `anim_scanpath` controls point size via the `size` argument

## Testing
- `R --version` *(fails: command not found)*
- `R -q -e "devtools::test()"` *(fails: command not found)*