### PR TITLE
Add min_fixations option

### DIFF
--- a/R/density.R
+++ b/R/density.R
@@ -10,6 +10,9 @@
 #' @param outdim A numeric vector of length 2 specifying the dimensions of the output density matrix (default is c(100, 100)).
 #' @param duration_weighted A logical value indicating whether the density should be weighted by fixation duration (default is TRUE).
 #' @param window A numeric vector of length 2 specifying the time window for selecting fixations (default is NULL).
+#' @param min_fixations Minimum number of fixations required for computing a density map.
+#'   Rows with fewer fixations after optional filtering will receive `NULL` in the
+#'   result column. Default is 2.
 #' @param keep_vars A character vector specifying additional variables to keep in the output (default is NULL).
 #' @param result_name A character string specifying the name for the density result variable (default is "density").
 #' @param ... Additional arguments passed to the `eye_density.fixation_group` function.
@@ -35,7 +38,8 @@
 #' @importFrom dplyr group_by do rowwise
 #' @importFrom tibble as_tibble
 density_by <- function(x, groups, sigma=50, xbounds=c(0, 1000), ybounds=c(0, 1000), outdim=c(100,100),
-                       duration_weighted=TRUE, window=NULL, keep_vars=NULL, fixvar="fixgroup", result_name="density", ...) {
+                       duration_weighted=TRUE, window=NULL, min_fixations=2,
+                       keep_vars=NULL, fixvar="fixgroup", result_name="density", ...) {
 
   ## TODO what happens if window produces fixations < 0?
 
@@ -54,6 +58,7 @@ density_by <- function(x, groups, sigma=50, xbounds=c(0, 1000), ybounds=c(0, 100
         d <- eye_density(.[[fixvar]], sigma,
                          xbounds = xbounds, ybounds = ybounds, outdim = outdim,
                          duration_weighted = duration_weighted, window = window,
+                         min_fixations = min_fixations,
                          origin = attr(x, "origin"), ...)
         cbind(as_tibble(.[vars]),
               tibble(!!fixvar := list(.[[fixvar]]), !!rname := list(d)))
@@ -62,7 +67,9 @@ density_by <- function(x, groups, sigma=50, xbounds=c(0, 1000), ybounds=c(0, 100
     #browser()
     fx <- do.call(rbind, x[[fixvar]])
     d <- eye_density(fx, sigma, xbounds=xbounds, ybounds=ybounds, outdim=outdim,
-                     duration_weighted=duration_weighted, window=window,origin=attr(x, "origin"), ...)
+                     duration_weighted=duration_weighted, window=window,
+                     min_fixations=min_fixations,
+                     origin=attr(x, "origin"), ...)
     ret <- tibble(!!fixvar := list(fx), !!rname := list(d))
 
   }

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -345,11 +345,18 @@ print.eye_density <- function(x,...) {
 #' @param normalize Whether to normalize the output map. Default is TRUE.
 #' @param duration_weighted Whether to weight the fixations by their duration. Default is FALSE.
 #' @param window The temporal window over which to compute the density map. Default is NULL.
+#' @param min_fixations Minimum number of fixations required to compute a density map.
+#'   If fewer fixations are present after optional filtering, the function returns NULL.
+#'   Default is 2.
 #' @param origin The origin of the coordinate system. Default is c(0,0).
 #'
 #' @details The function computes a density map for a given fixation group using kernel density estimation. If `sigma` is a single value, it computes a standard density map. If `sigma` is a vector, it computes a density map for each value in `sigma` and returns them packaged as an `eye_density_multiscale` object, which is a list of individual `eye_density` objects.
 #'
-#' @return An object of class `eye_density` (inheriting from `density` and `list`) if `sigma` is a single value, or an object of class `eye_density_multiscale` (a list of `eye_density` objects) if `sigma` is a vector. Returns `NULL` if filtering by `window` leaves fewer than 2 fixations, or if density computation fails (e.g., due to zero weights).
+#' @return An object of class `eye_density` (inheriting from `density` and `list`) if
+#'   `sigma` is a single value, or an object of class `eye_density_multiscale` (a
+#'   list of `eye_density` objects) if `sigma` is a vector. Returns `NULL` if
+#'   filtering by `window` leaves fewer than `min_fixations` fixations, or if
+#'   density computation fails (e.g., due to zero weights).
 #' @export
 #' @importFrom ks kde
 #' @importFrom dplyr filter
@@ -359,7 +366,8 @@ eye_density.fixation_group <- function(x, sigma = 50,
                                        ybounds = c(min(x$y), max(x$y)),
                                        outdim = c(100, 100),
                                        normalize = TRUE, duration_weighted = FALSE,
-                                       window = NULL, origin = c(0, 0),
+                                       window = NULL, min_fixations = 2,
+                                       origin = c(0, 0),
                                        kde_pkg = "ks",
                                        ...) {
 
@@ -383,8 +391,10 @@ eye_density.fixation_group <- function(x, sigma = 50,
   }
 
   # Basic check for enough data points for KDE
-  if (nrow(x_filtered) < 2) {
-      warning("Not enough fixations (need >= 2) to compute density. Returning NULL. Provided: ", nrow(x_filtered))
+  if (nrow(x_filtered) < min_fixations) {
+      warning(paste0("Not enough fixations (need >= ", min_fixations,
+                     ") to compute density. Returning NULL. Provided: ",
+                     nrow(x_filtered)))
       return(NULL)
   }
 

--- a/man/density_by.Rd
+++ b/man/density_by.Rd
@@ -13,6 +13,7 @@ density_by(
   outdim = c(100, 100),
   duration_weighted = TRUE,
   window = NULL,
+  min_fixations = 2,
   keep_vars = NULL,
   fixvar = "fixgroup",
   result_name = "density",
@@ -35,6 +36,8 @@ density_by(
 \item{duration_weighted}{A logical value indicating whether the density should be weighted by fixation duration (default is TRUE).}
 
 \item{window}{A numeric vector of length 2 specifying the time window for selecting fixations (default is NULL).}
+
+\item{min_fixations}{Minimum number of fixations required for computing a density map. Rows with fewer fixations will receive \code{NULL} results. Default is 2.}
 
 \item{keep_vars}{A character vector specifying additional variables to keep in the output (default is NULL).}
 

--- a/man/eye_density.fixation_group.Rd
+++ b/man/eye_density.fixation_group.Rd
@@ -13,6 +13,7 @@
   normalize = TRUE,
   duration_weighted = FALSE,
   window = NULL,
+  min_fixations = 2,
   origin = c(0, 0)
 )
 }
@@ -32,6 +33,8 @@
 \item{duration_weighted}{Whether to weight the fixations by their duration. Default is FALSE.}
 
 \item{window}{The temporal window over which to compute the density map. Default is NULL.}
+
+\item{min_fixations}{Minimum number of fixations required to compute a density map. If fewer are present after filtering, the function returns \code{NULL}. Default is 2.}
 
 \item{origin}{The origin of the coordinate system. Default is c(0,0).}
 }

--- a/tests/testthat/test_density_by.R
+++ b/tests/testthat/test_density_by.R
@@ -78,3 +78,19 @@ test_that("weighted and unweighted density maps are highly correlated", {
   # Test that correlation is above 0.95 for clustered data
   expect_gt(correlation2, 0.95)
 })
+
+test_that("density_by handles min_fixations correctly", {
+  fg_single <- fixation_group(x = 100, y = 100, onset = 1, duration = 1)
+  tab <- tibble(fixgroup = list(fg_single), grp = 1)
+
+  dens_default <- expect_warning(
+    density_by(tab, groups = "grp", xbounds = c(0, 200), ybounds = c(0, 200)),
+    "Removing rows"
+  )
+  expect_equal(nrow(dens_default), 0)
+
+  dens_allowed <- density_by(tab, groups = "grp", xbounds = c(0, 200),
+                             ybounds = c(0, 200), min_fixations = 1)
+  expect_equal(nrow(dens_allowed), 1)
+  expect_s3_class(dens_allowed$density[[1]], "eye_density")
+})


### PR DESCRIPTION
## Summary
- allow eye_density to accept a `min_fixations` argument
- pass `min_fixations` through density_by
- document the new argument in Rd files
- test density_by when only a single fixation is present

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*