### PR TITLE
Refactor sample_density to use vectorized lookup

### DIFF
--- a/R/similarity.R
+++ b/R/similarity.R
@@ -246,26 +246,25 @@ template_similarity <- function(ref_tab, source_tab, match_on, permute_on = NULL
 #'
 #' @return A data frame with columns "z" and "time", where "z" contains the sampled density values and "time" contains the corresponding time points.
 #' @export
-sample_density.density <- function(x, fix, times=NULL) {
+sample_density.density <- function(x, fix, times = NULL) {
+  nearest_index <- function(coord, grid) {
+    ind <- round(approx(grid, seq_along(grid), coord, rule = 2)$y)
+    ind[ind < 1L] <- 1L
+    ind[ind > length(grid)] <- length(grid)
+    ind
+  }
+
   if (is.null(times)) {
-    cds <- as.matrix(cbind(fix$x, fix$y))
-    ix <- sapply(cds[,1], function(p) which.min(abs(x$x - p)))
-    iy <- sapply(cds[,2], function(p) which.min(abs(x$y - p)))
-    data.frame(z=x$z[cbind(ix,iy)], time=fix$onset)
+    cds <- cbind(fix$x, fix$y)
+    ix <- nearest_index(cds[, 1], x$x)
+    iy <- nearest_index(cds[, 2], x$y)
+    data.frame(z = x$z[cbind(ix, iy)], time = fix$onset)
   } else {
     fg <- sample_fixations(fix, times)
-    cds <- as.matrix(cbind(fg$x, fg$y))
-    res <- lapply(1:nrow(cds), function(i) {
-      i1 <- which.min(abs(x$x - cds[i,1]))
-      i2 <- which.min(abs(x$y - cds[i,2]))
-      if (length(i1) > 0) {
-        x$z[i1,i2]
-      } else {
-        NA
-      }
-    })
-
-    data.frame(z=unlist(res), time=times)
+    cds <- cbind(fg$x, fg$y)
+    ix <- nearest_index(cds[, 1], x$x)
+    iy <- nearest_index(cds[, 2], x$y)
+    data.frame(z = x$z[cbind(ix, iy)], time = times)
   }
 }
 

--- a/tests/testthat/test_sample_density.R
+++ b/tests/testthat/test_sample_density.R
@@ -1,0 +1,22 @@
+context("sample_density vectorization")
+
+library(testthat)
+
+# Simple density map
+x_grid <- seq(0, 10, by = 1)
+y_grid <- seq(0, 10, by = 1)
+z_mat <- outer(x_grid, y_grid, function(a,b) a + b)
+dens <- list(x = x_grid, y = y_grid, z = z_mat)
+class(dens) <- c("eye_density", "density", "list")
+
+# fixation group
+fix <- fixation_group(x = c(1,5,10),
+                      y = c(2,5,9),
+                      onset = c(0,50,100),
+                      duration = rep(1,3))
+
+test_that("times argument matches direct sampling", {
+  direct <- sample_density(dens, fix)
+  timed  <- sample_density(dens, fix, times = fix$onset)
+  expect_equal(direct, timed)
+})


### PR DESCRIPTION
## Summary
- refactor `sample_density.density` to replace loops with `approx`
- add regression test for equivalent times behavior

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470636f23c832d892f8d2e31dde5c2