### PR TITLE
Add tests for fixation_overlap, suggest_sigma, and c.fixation_group

### DIFF
--- a/tests/testthat/test_weak_areas.R
+++ b/tests/testthat/test_weak_areas.R
@@ -1,0 +1,75 @@
+test_that("fixation_overlap matches deterministic overlap counts across metrics", {
+  fg_ref <- fixation_group(
+    x = c(0, 10, 20),
+    y = c(0, 0, 0),
+    onset = c(0, 100, 200),
+    duration = c(100, 100, 100)
+  )
+
+  fg_shift <- fixation_group(
+    x = c(2, 15, 40),
+    y = c(1, 0, 0),
+    onset = c(0, 100, 200),
+    duration = c(100, 100, 100)
+  )
+
+  times <- c(0, 100, 200)
+
+  euclidean <- fixation_overlap(fg_ref, fg_shift, dthresh = 6,
+                                time_samples = times,
+                                dist_method = "euclidean")
+  manhattan <- fixation_overlap(fg_ref, fg_shift, dthresh = 6,
+                                time_samples = times,
+                                dist_method = "manhattan")
+
+  expect_equal(euclidean$overlap, 2)
+  expect_equal(euclidean$perc, 2 / 3)
+  expect_equal(manhattan$overlap, 2)
+  expect_equal(manhattan$perc, 2 / 3)
+})
+
+test_that("suggest_sigma enforces input requirements and display-based clamp", {
+  expect_error(
+    suggest_sigma(c(1, 2, 3)),
+    "'y' must be provided"
+  )
+
+  fg_tight <- fixation_group(
+    x = rep(400, 20),
+    y = rep(300, 20),
+    onset = seq(0, by = 50, length.out = 20),
+    duration = rep(50, 20)
+  )
+
+  sigma <- suggest_sigma(fg_tight, xbounds = c(0, 1000), ybounds = c(0, 1000))
+
+  expect_equal(sigma, 10)
+})
+
+test_that("c.fixation_group concatenates sequentially and rejects invalid inputs", {
+  fg1 <- fixation_group(
+    x = c(10, 20),
+    y = c(5, 10),
+    onset = c(0, 100),
+    duration = c(100, 100)
+  )
+
+  fg2 <- fixation_group(
+    x = c(30, 40),
+    y = c(15, 20),
+    onset = c(0, 100),
+    duration = c(100, 100)
+  )
+
+  combined <- c(fg1, fg2)
+
+  expect_s3_class(combined, "fixation_group")
+  expect_equal(nrow(combined), 4)
+  expect_equal(combined$index, 1:4)
+  expect_equal(combined$onset, c(0, 100, 200, 300))
+
+  expect_error(
+    c(fg1, data.frame(x = 1)),
+    "must be fixation_group"
+  )
+})


### PR DESCRIPTION
### Motivation
- Improve coverage for weakly tested utilities around overlap calculation, kernel-bandwidth suggestion, and fixation-group concatenation. 

### Description
- Add `tests/testthat/test_weak_areas.R` containing three focused tests that exercise `fixation_overlap()` for deterministic overlap and percentage results across `euclidean` and `manhattan` metrics. 
- Add a `suggest_sigma()` test that verifies required-argument validation when `y` is missing and asserts display-based clamping behavior for near-zero spatial spread. 
- Add a `c.fixation_group()` test that verifies sequential onset shifting, index re-numbering, and rejection of non-`fixation_group` inputs. 

### Testing
- Attempted to run the new test file with `R -q -e "testthat::test_file('tests/testthat/test_weak_areas.R')"`, but execution failed because the `R` executable is not available in this environment. 
- No other automated test commands were run locally in this environment due to the missing `R` runtime. 
- The new test file is self-contained and follows repository testing conventions so it should run under the standard test harness (`R -q -e "devtools::test()"`) in CI or a developer environment with `R` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa228f7934832d992eb98d70b8bfad)